### PR TITLE
Make layout a bit more mobile friendly

### DIFF
--- a/src/crowcraft/src/components/crafting/Crafting.jsx
+++ b/src/crowcraft/src/components/crafting/Crafting.jsx
@@ -67,7 +67,7 @@ export const Crafting = () => {
     return (
         <div className="flex mv3">
             <div className="flex">
-                <div className="mr5">
+                <div className="mr5 mobile-hide">
                     <div className="sticky-sidebar">
                         <CrafterConfiguration onConfigurationChanged={handleConfigurationChanged} />
                     </div>

--- a/src/crowcraft/src/components/crafting/professions-status/ProfessionsStatus.jsx
+++ b/src/crowcraft/src/components/crafting/professions-status/ProfessionsStatus.jsx
@@ -19,7 +19,7 @@ export const ProfessionsStatus = () => {
     return (
         <div>
             <div className="mb2 f3 fw5">Implemented professions</div>
-            <div className="flex items-center">
+            <div className="flex items-center flex-wrap">
                 {Object.entries(professionsStatus).map(([profession, isReady]) => (
                     <div className="mr2 relative" key={profession}>
                         <div className="w5 h5 flex items-center justify-center">

--- a/src/crowcraft/src/components/layout/Layout.jsx
+++ b/src/crowcraft/src/components/layout/Layout.jsx
@@ -4,10 +4,10 @@ import { Footer } from "./footer";
 
 export const Layout = ({ children }) => (
     <div className="bg-charcoal peach-puff">
-        <Header className="h5 nmb5 ph7" />
-        <Content className="flex pv5 pl6 pr7 min-vh-100">
+        <Header className="nmb5" />
+        <Content className="flex pv5 min-vh-100 ph2 m0auto mw8">
             {children}
         </Content>
-        <Footer className="h5 nmt5 ph7" />
+        <Footer className="h5 nmt5" />
     </div>
 );

--- a/src/crowcraft/src/components/layout/header/Header.jsx
+++ b/src/crowcraft/src/components/layout/header/Header.jsx
@@ -4,16 +4,18 @@ import logo from "./logo.svg";
 import discord from "./discord.svg";
 
 export const Header = ({ className }) => (
-    <div className={className + " flex justify-between items-center bg-marine bb bw1"}>
-        <div className="flex items-center h-100">
-            <img src={logo} alt="Crowcraft logo" className="h-50 mr2" />
-            <div className="tag fw5 f7 pt2">BETA 6.540</div>
-        </div>
-        <div className="flex items-center">
-            <a className="mr4 w7 tc" href="https://discord.gg/Ju87JBQGJw" title="Join our Discord!" target="_blank" rel="noopener noreferrer">Found a bug or want to help?</a>
-            <a className="w7" href="https://discord.gg/Ju87JBQGJw" target="_blank" rel="noopener noreferrer">
-                <img src={discord} alt="Discord logo" title="Join our Discord!" />
-            </a>
+    <div className={className + " flex bg-marine bb bw1"}>
+        <div className="flex justify-between items-center flex-wrap w-100 ph2 m0auto mw8">
+            <div className="flex items-center pv3">
+                <img src={logo} alt="Crowcraft logo" className="h2 mr2" />
+                <div className="tag fw5 f7 pt2">BETA 6.540</div>
+            </div>
+            <div className="flex items-center pv3">
+                <a className="mr4 w7 tc" href="https://discord.gg/Ju87JBQGJw" title="Join our Discord!" target="_blank" rel="noopener noreferrer">Found a bug or want to help?</a>
+                <a className="w7" href="https://discord.gg/Ju87JBQGJw" target="_blank" rel="noopener noreferrer">
+                    <img src={discord} alt="Discord logo" title="Join our Discord!" />
+                </a>
+            </div>
         </div>
     </div>
 );

--- a/src/crowcraft/src/global.css
+++ b/src/crowcraft/src/global.css
@@ -7,6 +7,10 @@
     margin-bottom: -4rem;
 }
 
+.m0auto {
+    margin: 0 auto;
+}
+
 /* Color Palette */
 .verdigris {
     color: #00AFB9;
@@ -213,4 +217,15 @@ a:visited {
 /* Flex */
 .justify-evenly {
     justify-content: space-evenly
+}
+
+/* Mobile */
+.mobile-hide {
+    display: block;
+}
+
+@media (max-width: 767px) {
+    .mobile-hide {
+        display: none;
+    }
 }


### PR DESCRIPTION
Not perfect, but a start. Currently hiding the professions configuration all-together, but optimally that will be pushed below or above the crafting interface, or in an expanding side nav.

Before:

https://user-images.githubusercontent.com/7316699/126904340-f4487487-9d05-49fd-8e08-e8a0202c0190.mov

After:

https://user-images.githubusercontent.com/7316699/126904345-c04fc087-913c-4014-81dc-608a1128f238.mov

