### PR TITLE
Persist crafting professions with local state (#38)

### DIFF
--- a/src/crowcraft/src/components/crafting/Crafting.jsx
+++ b/src/crowcraft/src/components/crafting/Crafting.jsx
@@ -4,6 +4,7 @@ import { ItemSearch } from "./item-search";
 import { RawMaterials } from "./raw-materials";
 import { RarityPicker } from "./rarity-picker";
 import { CraftingSteps } from "./CraftingSteps";
+import useLocalState from "../hooks/useLocalState";
 import { ItemCustomizer } from "./item-customizer";
 import { ProfessionsStatus } from "./professions-status";
 import { CrafterConfiguration } from "./crafter-configuration";
@@ -17,7 +18,8 @@ export const Crafting = () => {
     const [crafts, setCrafts] = useState(null);
     const [triggerItemCraft, setTriggerItemCraft] = useState(false);
     const [itemIsCustomized, setItemIsCustomized] = useState(false);
-    const [crafterConfiguration, setCrafterConfiguration] = useState(undefined);
+    const [crafterConfiguration, setCrafterConfiguration] = useLocalState("crafterConfiguration", undefined);
+
 
     useEffect(
         () => {
@@ -69,7 +71,7 @@ export const Crafting = () => {
             <div className="flex">
                 <div className="mr5 mobile-hide">
                     <div className="sticky-sidebar">
-                        <CrafterConfiguration onConfigurationChanged={handleConfigurationChanged} />
+                        <CrafterConfiguration defaultConfiguration={crafterConfiguration} onConfigurationChanged={handleConfigurationChanged} />
                     </div>
                 </div>
                 <div>

--- a/src/crowcraft/src/components/crafting/crafter-configuration/CrafterConfiguration.jsx
+++ b/src/crowcraft/src/components/crafting/crafter-configuration/CrafterConfiguration.jsx
@@ -23,8 +23,8 @@ const initProfessionSettings = value => {
     }, {});
 }
 
-export const CrafterConfiguration = ({ onConfigurationChanged }) => {
-    const [configuration, setConfiguration] = useState(initProfessionSettings(NONE));
+export const CrafterConfiguration = ({ defaultConfiguration, onConfigurationChanged }) => {
+    const [configuration, setConfiguration] = useState(defaultConfiguration || initProfessionSettings(NONE));
 
     const handleProfessionSettingChanged = (profession, newProfessionSetting) => {
         const newConfiguration = { ...configuration };

--- a/src/crowcraft/src/components/hooks/useLocalState.js
+++ b/src/crowcraft/src/components/hooks/useLocalState.js
@@ -1,0 +1,26 @@
+import { useState, useCallback } from "react";
+
+export default function useLocalState(name, initialState = null, reviver = undefined) {
+    const json = localStorage.getItem(name);
+    
+    if (json !== null) {
+        initialState = JSON.parse(json, reviver);
+    }
+
+    const [state, setState] = useState(initialState);
+
+    const setLocal = useCallback(
+        newState => {
+            if (newState === null) {
+                localStorage.removeItem(name);
+                setState(newState);
+                return;
+            }
+            localStorage.setItem(name, JSON.stringify(newState));
+            setState(newState);
+        },
+        [setState, name]
+    );
+
+    return [state, setLocal];
+}


### PR DESCRIPTION
Added hook that allows you to persist data to local state. Hook will manage saving and loading of the data.

Closes #38 